### PR TITLE
add login css

### DIFF
--- a/css/islandora_muni_template.css
+++ b/css/islandora_muni_template.css
@@ -922,3 +922,22 @@ body.user-logged-in textarea.form-text {
 .form-item .description {
   margin: 0;
 }
+
+/* login */
+nav.navigation.menu--account,
+#block-islandora-muni-languageswitcher,
+#block-languageswitcher {
+	float: none;
+	padding-left: 1rem;
+}
+
+nav.navigation.menu--account {
+	width: auto;
+}
+
+nav.navigation.menu--account a {
+	font-size: 1.3rem;
+	padding: 0;
+  padding-top: 1.2rem;
+  color: #0000DC;
+}


### PR DESCRIPTION
Add login button to the top of the platform next to the language switcher. Tested on Herbaria devel. In order for it to work configuration changes need to be done, these are described in the [AAI documentation](https://github.com/ArtsFacultyMU/digitalia-documentation/blob/main/000_General/infrastructure/AAI.md#5-set-up-login-page).

<img width="1224" height="782" alt="hrm_login" src="https://github.com/user-attachments/assets/b2e8ccc3-ae40-4288-97d9-cd55ffd653c1" />
